### PR TITLE
Abstract out subreddit-suggestion text color

### DIFF
--- a/src/components/SavedPost/style.scss
+++ b/src/components/SavedPost/style.scss
@@ -6,7 +6,6 @@
   width:100%;
 
   h4{
-    color: #0079D3;
+    color: var(--color--text--subreddit-suggestion);
   }
 }
-

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,6 +9,8 @@
 
   --font-stack--normal: 'Noto Sans', Verdana, sans-serif;
   --font-stack--monospace: 'Noto Mono', Menlo, Consolas, monospace;
+
+  --color--reddit-blue: #0079D3; // from New Reddit's --newCommunityTheme-button
 }
 
 // Literally the only reason why all this is in an @media block is so the :root inside can be at the same nesting level as the @media (prefers-color-scheme: dark) block.
@@ -19,6 +21,8 @@
 
     --color--text--link-unvisited: hsl(180, 100%, 25%);
     --color--text--link-visited: hsl(270, 100%, 25%);
+
+    --color--text--subreddit-suggestion: var(--color--reddit-blue);
   }
 }
 
@@ -29,6 +33,9 @@
 
     --color--text--link-unvisited: hsl(180, 80%, 50%);
     --color-text--link-visited: hsl(270, 80%, 70%);
+
+    // Actually the same color as in light mode. Unlike most text colors, this one works well enough against both a light and dark background, assuming you don’t need a particularly high contrast ratio.
+    --color--text--subreddit-suggestion: var(--color--reddit-blue);
   }
 }
 
@@ -48,4 +55,3 @@ a:visited {
 code {
   font-family: var(--font-stack--monospace);
 }
-


### PR DESCRIPTION
This sets us up to have slightly different subreddit-suggestion colors in both light and dark mode.

It also demonstrates how to have a base set of colors in a `:root` block somewhere, then have semantic names for those colors overridden in `prefers-color-scheme` blocks.

Since this is your code I'm touching, it's up to you whether to merge or drop this PR.